### PR TITLE
Added HTML/CSS naming convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 prepros-6.config
 .DS_Store
+node_modules

--- a/docs/guide/naming_convention.json
+++ b/docs/guide/naming_convention.json
@@ -1,0 +1,132 @@
+{
+  "desc" : "Ulight - A light Framework for Front-End Developer to build original and artistic websites!",
+  "body" : {
+    "desc" : "HTML Body",
+    "selector" : {
+      "default" : "body"
+    },
+    "theme" : {
+      "desc" : "Eg: <body class='t-light'>",
+      "selector" : {
+        "christmas" : ".t-christmas",
+        "light" : ".t-light",
+        "news" : ".t-news",
+        "rebecca" : ".t-rebeccapurple"
+      }
+    },
+
+    "children" : {
+      "header" : {
+        "desc" : "Header",
+        "selector" : {
+          "default" : "header",
+          "ulight" : "#header"
+        },
+        "layout" : {
+          "fullheight" : ".fullheight",
+          "halfheight" : ".halfheight",
+          "fixed" : ".fixed"
+        },
+
+        "children" : {
+
+          "site_title" : {
+            "desc" : "Site Title",
+            "selector" : {
+              "default" : "h1#site-title",
+              "ulight" : "#site-title"
+            }
+          },
+
+          "site_description" : {
+            "desc" : "Site Description",
+            "selector" : {
+              "default" : "h2#site-description",
+              "ulight" : "#site-description"
+            }
+          },
+
+          "nav" : {
+            "desc" : "Navigation",
+            "selector" : {
+              "default" : "nav",
+              "ulight" : "#nav"
+            },
+            "layout" : {
+              "fixed" : ".fixed",
+            },
+          }
+        }
+      },
+
+      "main" : {
+        "desc" : "Main container",
+        "selector" : {
+          "default" : "main",
+          "ulight" : "#main"
+        },
+        "layout" : {
+          "fullwidth" : ".fullwidth",
+        },
+
+        "children" : {
+
+          "section" : {
+            "desc" : "Section",
+            "selector" : {
+              "default" : "section",
+              "ulight" : ".section"
+            },
+            "layout" : {
+              "fullheight" : ".fullheight",
+              "halfheight" : ".halfheight"
+            }
+          },
+
+          "article" : {
+            "desc" : "Article",
+            "selector" : {
+              "default" : "article",
+              "ulight" : ".article"
+            },
+            "layout" : {
+              "highlight" : ".highlight"
+            },
+
+            "children" : {
+
+              "header" : {
+                "selector" : {
+                  "default" : "article header"
+                }
+              }
+            }
+          },
+
+          "aside" : {
+            "desc" : "Sidebar",
+            "selector" : {
+              "default" : "aside",
+              "ulight" : ".sidebar",
+            },
+            "layout" : {
+              "left" : ".left",
+              "right" : ".right"
+            }
+          }
+        }
+      },
+
+      "footer" : {
+        "desc" : "Footer",
+        "selector" : {
+          "default" : "footer",
+          "ulight" : "#footer"
+        },
+        "layout" : {
+          "fixed" : ".fixed",
+        }
+      }
+    }
+  },
+}

--- a/src/index.html
+++ b/src/index.html
@@ -26,7 +26,8 @@
   <link rel="prefetch" href="index.html">
 
   <title>Ulight</title>
-  <meta name="description" content="">
+  <meta name="description" content="A light Framework for Front-End Developer to build original and artistic websites!">
+  <meta name="keywords" content="udacity, ulight framework">
   <meta name="robots" content="all">
 
   <!-- Mobile Metas -->


### PR DESCRIPTION
The naming convention is here to help keep track of HTML element class assignments so we have something to turn to when we use CSS or JS to access the elements.

## Current Theme Logic
1. Assign theme name class to `<body>`. Example:
`<body class='t-christmas'>`
2. Use `.t-christmass` as selector for custom theme styles. Example:
```css
.t-christmas header,
.t-christmas nav,
.t-christmas main,
.t-christmas footer {
    background: red;
}
```
  
  